### PR TITLE
Specify build job rather than workflow.

### DIFF
--- a/otterdog/eclipse-osee.jsonnet
+++ b/otterdog/eclipse-osee.jsonnet
@@ -56,7 +56,7 @@ orgs.newOrg('eclipse-osee') {
           requires_strict_status_checks: true,
           required_status_checks : [
             "eclipse-eca-validation:eclipsefdn/eca",
-            "OSEE Build Validation/validate_osee_build_linux",
+            "validate_osee_build_linux",
           ],
         },
       ]

--- a/otterdog/eclipse-osee.jsonnet
+++ b/otterdog/eclipse-osee.jsonnet
@@ -56,7 +56,7 @@ orgs.newOrg('eclipse-osee') {
           requires_strict_status_checks: true,
           required_status_checks : [
             "eclipse-eca-validation:eclipsefdn/eca",
-            "OSEE Build Validation",
+            "OSEE Build Validation/validate_osee_build_linux",
           ],
         },
       ]


### PR DESCRIPTION
Previously targeted entire workflow which caused pending status. Now targeting job specifically. 