### PR TITLE
add OSEE_PACKAGE_REGISTRY_MANAGEMENT_BOT

### DIFF
--- a/otterdog/eclipse-osee.jsonnet
+++ b/otterdog/eclipse-osee.jsonnet
@@ -18,6 +18,11 @@ orgs.newOrg('eclipse-osee') {
       ],
     },
   ],
+  secrets+: [
+    orgs.newOrgSecret('OSEE_PACKAGE_REGISTRY_MANAGEMENT_BOT') {
+      value: "pass:bots/org.eclipse.osee/github.com/project-token",
+    },
+  ],
   _repositories+:: [
     orgs.newRepo('osee-website') {
       description: "OSEE Website",


### PR DESCRIPTION
Requesting to add OSEE_PACKAGE_REGISTRY_MANAGEMENT_BOT with permissions to write, read, and delete from the package's registry.

We wish to delete "development" containers using a workflow like so: 
https://github.com/eclipse-osee/org.eclipse.osee/blob/main/.github/workflows/clean-up.yml